### PR TITLE
Support exact object type

### DIFF
--- a/src/converters/convert_flow_type.ts
+++ b/src/converters/convert_flow_type.ts
@@ -253,6 +253,7 @@ export function convertFlowType(path: NodePath<FlowType>): TSType {
         const objectTypeNode = path.node as ObjectTypeAnnotation;
         if (objectTypeNode.exact) {
             warnOnlyOnce('Exact object type annotation in Flow is ignored. In TypeScript, it\'s always regarded as exact type');
+            objectTypeNode.exact = false
         }
 
         if (objectTypeNode.properties && objectTypeNode.properties.length > 0) {

--- a/test/visitors/type_annotation.test.ts
+++ b/test/visitors/type_annotation.test.ts
@@ -69,6 +69,12 @@ pluginTester({
         code: `let a: $ElementType<T, k>;`,
         output: `let a: T[k];`
     }, {
+        title: 'Object type: exact=true',
+        code: `let a: {| a: T |};`,
+        output: `let a: {
+  a: T;
+};`
+    }, {
         title: 'Intersection type',
         code: `let a: {x: number} & {y: string};`,
         output: `let a: {


### PR DESCRIPTION
```js
let a: {| a: T |};
```

to

```ts
let a: {
  a: T;
};
```
