### PR TITLE
Support typeof keyword

### DIFF
--- a/src/converters/convert_flow_type.ts
+++ b/src/converters/convert_flow_type.ts
@@ -320,7 +320,9 @@ export function convertFlowType(path: NodePath<FlowType>): TSType {
     }
 
     if (isNodePath(isTypeofTypeAnnotation, path)) {
-        return tsTypeOperator(convertFlowType((path as NodePath<TypeofTypeAnnotation>).get('arguments')), 'typeof');
+        const typeOp = tsTypeOperator(convertFlowType((path as NodePath<TypeofTypeAnnotation>).get('argument')));
+        typeOp.operator = 'typeof'
+        return typeOp
     }
 
     if (isNodePath(isUnionTypeAnnotation, path)) {

--- a/test/visitors/type_annotation.test.ts
+++ b/test/visitors/type_annotation.test.ts
@@ -33,6 +33,10 @@ pluginTester({
         code: `let a: empty;`,
         output: `let a: never;`,
     }, {
+        title: 'typeof keyword',
+        code: `let a: typeof A;`,
+        output: `let a: typeof A;`,
+    }, {
         title: 'Generic type',
         code: `let a: X<T>;`,
         output: `let a: X<T>;`
@@ -40,6 +44,10 @@ pluginTester({
         title: 'Utility generics: $Keys',
         code: `let a: $Keys<X>;`,
         output: `let a: keyof X;`
+    }, {
+        title: 'Utility generics: $Keys with typeof',
+        code: `let a: $Keys<typeof X>;`,
+        output: `let a: keyof typeof X;`
     }, {
         title: 'Utility generics: $Values',
         code: `let a: $Values<X>;`,


### PR DESCRIPTION
I added transformation about `typeof` keyword.

Flow

```js
/* @flow */

const m = {
  a: 1,
  b: 2,
  c: 3
}

const a: $Keys<typeof m> = 'a'
```

playground: https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBjOA7AzgFzAFswBeMAb1TDAEMAuMARgBpqwAjRgJjZo0YBmVAF90WPIQZgAJAGkApgE9cAHnxKADgrhRiAPjJgA5LWOogA

---

TypeScript

```ts
const m = {
  a: 1,
  b: 2,
  c: 3
}

const a: keyof typeof m = 'a'
```

http://www.typescriptlang.org/play/#src=const%20m%20%3D%20%7B%0D%0A%20%20a%3A%201%2C%0D%0A%20%20b%3A%202%2C%0D%0A%20%20c%3A%203%0D%0A%7D%0D%0A%0D%0Aconst%20a%3A%20keyof%20typeof%20m%20%3D%20'a'%0D%0A